### PR TITLE
Use MPAndroidChart for expense pie chart

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation("com.github.PhilJay:MPAndroidChart:v3.1.0")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/smartfinancesce/HomeActivity.kt
+++ b/app/src/main/java/com/example/smartfinancesce/HomeActivity.kt
@@ -4,6 +4,11 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
+import com.github.mikephil.charting.charts.PieChart
+import com.github.mikephil.charting.data.PieData
+import com.github.mikephil.charting.data.PieDataSet
+import com.github.mikephil.charting.data.PieEntry
+import com.github.mikephil.charting.utils.ColorTemplate
 
 class HomeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -14,6 +19,18 @@ class HomeActivity : AppCompatActivity() {
         val ivOrcamento = findViewById<ImageView>(R.id.ivOrcamento)
         val ivConta = findViewById<ImageView>(R.id.ivConta)
         val ivInicio = findViewById<ImageView>(R.id.ivInicio)
+        val pieChart = findViewById<PieChart>(R.id.pieChart)
+        val entries = listOf(
+            PieEntry(40f, "Alimentação"),
+            PieEntry(30f, "Transporte"),
+            PieEntry(30f, "Outros")
+        )
+        val dataSet = PieDataSet(entries, "")
+        dataSet.setColors(ColorTemplate.MATERIAL_COLORS.toList())
+        val data = PieData(dataSet)
+        pieChart.data = data
+        pieChart.description.isEnabled = false
+        pieChart.invalidate()
 
         ivInicio.setOnClickListener {
             startActivity(Intent(this, HomeActivity::class.java)) // você já está na Home

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -62,20 +62,18 @@
         android:textColor="#000000"
         android:layout_marginTop="4dp" />
 
-    <ImageView
-        android:id="@+id/graficoPizza"
+    <com.github.mikephil.charting.charts.PieChart
+        android:id="@+id/pieChart"
         android:layout_width="match_parent"
         android:layout_height="220dp"
         android:layout_below="@id/valorTotal"
-        android:layout_marginTop="85dp"
-        android:scaleType="fitCenter"
-        android:src="@drawable/ic_grafico_pizza" />
+        android:layout_marginTop="85dp" />
 
     <TextView
         android:id="@+id/analiseTitulo"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/graficoPizza"
+        android:layout_below="@id/pieChart"
         android:layout_marginTop="-210dp"
         android:text="Análise de gráficos"
         android:textColor="#000000"


### PR DESCRIPTION
## Summary
- replace static pie chart image with MPAndroidChart view
- populate chart with sample expense data
- add MPAndroidChart library dependency

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6891281d0530832bbcf802dd0bb5559a